### PR TITLE
odroid-c1: Use correct serial port

### DIFF
--- a/serial-it.sh
+++ b/serial-it.sh
@@ -129,7 +129,7 @@ case $BOARD in
         baudrate=115200
         ;;
     odroid-c1)
-        serialdev=ttyAML0
+        serialdev=ttyS0
         baudrate=115200
         ;;
     *)


### PR DESCRIPTION
Signed-off-by: Florin Sarbu <florin@resin.io>