### PR TITLE
serial-it.sh: Create symlinks for serial getty aliases

### DIFF
--- a/serial-it.sh
+++ b/serial-it.sh
@@ -144,7 +144,7 @@ if [ -f $ROOT_MOUNTPOINT/etc/systemd/system/getty.target.wants/serial-getty@${se
     echo "[WARN] $ROOT_MOUNTPOINT/etc/systemd/system/getty.target.wants/serial-getty@${serialdev}.service already exists."
 else
     mkdir -p $ROOT_MOUNTPOINT/etc/systemd/system/getty.target.wants
-    cp $ROOT_MOUNTPOINT/lib/systemd/system/serial-getty@.service $ROOT_MOUNTPOINT/etc/systemd/system/getty.target.wants/serial-getty@${serialdev}.service
+    ln -sf $ROOT_MOUNTPOINT/lib/systemd/system/serial-getty@.service $ROOT_MOUNTPOINT/etc/systemd/system/getty.target.wants/serial-getty@${serialdev}.service
     sed -i -e s/\@BAUDRATE\@/$baudrate/g $ROOT_MOUNTPOINT/etc/systemd/system/getty.target.wants/serial-getty@${serialdev}.service
 fi
 


### PR DESCRIPTION
This is the proper way to auto start getty on serial consoles

Signed-off-by: Florin Sarbu <florin@resin.io>